### PR TITLE
Update the way teams are showed on gossip

### DIFF
--- a/src/ArenaSpectatorNPC.cpp
+++ b/src/ArenaSpectatorNPC.cpp
@@ -86,15 +86,16 @@ std::string ArenaSpectatorNPC::GetGamesStringData(Battleground* team, uint16 mmr
             teamsMember[firstTeamId == team] += GetClassIconById(player->getClass());
         }
 
-    std::string data = teamsMember[0] + "" + secondTeamName + " (";
+    std::string data = " " + teamsMember[0] + " " + secondTeamName + " (";
     std::stringstream ss;
     std::stringstream sstwo;
     ss << mmr;
     sstwo << mmrTwo;
     data += sstwo.str();
-    data += ") - ";
-    data += "(" + ss.str();
-    data += ") " + firstTeamName + "" + teamsMember[1];
+    data += ") vs\n";
+    data += " " + teamsMember[1] + " " + firstTeamName + " (";
+    data += ss.str();
+    data += ")";
     return data;
 }
 


### PR DESCRIPTION
Instead of showing like this, where in 3v3 or 5v5 or when teams have long names, the class icons doesn't fit properly:
![image](https://github.com/user-attachments/assets/436789f9-61ab-4e58-9f32-ebbff4770fa7)


With the fix it looks like that:
![image](https://github.com/user-attachments/assets/cbdd9b09-df78-48d8-ad53-9588070ea278)
