### PR TITLE
fix: remove deprecated creature_template columns from SQL

### DIFF
--- a/data/sql/db-world/ArenaSpectator.sql
+++ b/data/sql/db-world/ArenaSpectator.sql
@@ -1,6 +1,6 @@
 DELETE FROM `creature_template` WHERE `entry`=190000;
-INSERT INTO `creature_template` (`entry`, `name`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `scale`, `rank`, `dmgschool`, `baseattacktime`, `rangeattacktime`, `unit_class`, `unit_flags`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `RegenHealth`, `mechanic_immune_mask`, `flags_extra`, `ScriptName`) VALUES
-(190000, "Arena Spectator", "Speak", 0, 80, 80, 2, 35, 3, 1, 0, 0, 2000, 0, 1, 0, 7, 138936390, 0, 0, 0, '', 0, 1, 0, 0, 1, 0, 16777216, 'ArenaSpectatorNPC_Creature');
+INSERT INTO `creature_template` (`entry`, `name`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `exp`, `faction`, `npcflag`, `rank`, `dmgschool`, `baseattacktime`, `rangeattacktime`, `unit_class`, `unit_flags`, `type`, `type_flags`, `lootid`, `pickpocketloot`, `skinloot`, `AIName`, `MovementType`, `HoverHeight`, `RacialLeader`, `movementId`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
+(190000, "Arena Spectator", "Speak", 0, 80, 80, 2, 35, 3, 0, 0, 2000, 0, 1, 0, 7, 138936390, 0, 0, 0, '', 0, 1, 0, 0, 1, 16777216, 'ArenaSpectatorNPC_Creature');
 
 DELETE FROM `creature_template_model` WHERE `CreatureID` = 190000;
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES


### PR DESCRIPTION
## Summary
- Removes `scale` and `mechanic_immune_mask` columns from `creature_template` INSERT statement
- These columns were removed from AzerothCore's `creature_template` table:
  - `scale` → moved to `creature_template_model.DisplayScale`
  - `mechanic_immune_mask` → replaced by `CreatureImmunitiesId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)